### PR TITLE
Count tokens without locks

### DIFF
--- a/lib/tiktoken.ex
+++ b/lib/tiktoken.ex
@@ -32,6 +32,10 @@ defmodule Tiktoken do
     delegate_call(model, :decode, [ids])
   end
 
+  def count_tokens(model, text, allowed_special \\ []) do
+    delegate_call(model, :count_tokens, [text, allowed_special])
+  end
+
   defp delegate_call(model, function, args) do
     if mod = encoding_for_model(model) do
       apply(mod, function, args)

--- a/lib/tiktoken/cl100k.ex
+++ b/lib/tiktoken/cl100k.ex
@@ -20,4 +20,9 @@ defmodule Tiktoken.CL100K do
   def decode(ids) do
     Tiktoken.Native.cl100k_decode(ids)
   end
+
+  @impl Tiktoken.Encoding
+  def count_tokens(text, allowed_special \\ []) do
+    Tiktoken.Native.cl100k_count_tokens(text, allowed_special)
+  end
 end

--- a/lib/tiktoken/encoding.ex
+++ b/lib/tiktoken/encoding.ex
@@ -6,4 +6,6 @@ defmodule Tiktoken.Encoding do
   @callback encode_with_special_tokens(String.t()) :: {:ok, [integer()]} | {:error, String.t()}
 
   @callback decode([integer()]) :: {:ok, String.t()} | {:error, String.t()}
+
+  @callback count_tokens(String.t(), [binary()]) :: {:ok, integer()} | {:error, String.t()}
 end

--- a/lib/tiktoken/native.ex
+++ b/lib/tiktoken/native.ex
@@ -16,26 +16,31 @@ defmodule Tiktoken.Native do
   def p50k_encode(_input, _allowed_special), do: err()
   def p50k_encode_with_special_tokens(_input), do: err()
   def p50k_decode(_ids), do: err()
+  def p50k_count_tokens(_input, _allowed_special), do: err()
 
   def p50k_edit_encode_ordinary(_input), do: err()
   def p50k_edit_encode(_input, _allowed_special), do: err()
   def p50k_edit_encode_with_special_tokens(_input), do: err()
   def p50k_edit_decode(_ids), do: err()
+  def p50k_edit_count_tokens(_input, _allowed_special), do: err()
 
   def r50k_encode_ordinary(_input), do: err()
   def r50k_encode(_input, _allowed_special), do: err()
   def r50k_encode_with_special_tokens(_input), do: err()
   def r50k_decode(_ids), do: err()
+  def r50k_count_tokens(_input, _allowed_special), do: err()
 
   def cl100k_encode_ordinary(_input), do: err()
   def cl100k_encode(_input, _allowed_special), do: err()
   def cl100k_encode_with_special_tokens(_input), do: err()
   def cl100k_decode(_ids), do: err()
+  def cl100k_count_tokens(_input, _allowed_special), do: err()
 
   def o200k_encode_ordinary(_input), do: err()
   def o200k_encode(_input, _allowed_special), do: err()
   def o200k_encode_with_special_tokens(_input), do: err()
   def o200k_decode(_ids), do: err()
+  def o200k_count_tokens(_input, _allowed_special), do: err()
 
   def context_size_for_model(_model), do: err()
 

--- a/lib/tiktoken/o200k.ex
+++ b/lib/tiktoken/o200k.ex
@@ -20,4 +20,9 @@ defmodule Tiktoken.O200K do
   def decode(ids) do
     Tiktoken.Native.o200k_decode(ids)
   end
+
+  @impl Tiktoken.Encoding
+  def count_tokens(text, allowed_special \\ []) do
+    Tiktoken.Native.o200k_count_tokens(text, allowed_special)
+  end
 end

--- a/lib/tiktoken/p50k.ex
+++ b/lib/tiktoken/p50k.ex
@@ -20,4 +20,9 @@ defmodule Tiktoken.P50K do
   def decode(ids) do
     Tiktoken.Native.p50k_decode(ids)
   end
+
+  @impl Tiktoken.Encoding
+  def count_tokens(text, allowed_special \\ []) do
+    Tiktoken.Native.p50k_count_tokens(text, allowed_special)
+  end
 end

--- a/lib/tiktoken/p50k_edit.ex
+++ b/lib/tiktoken/p50k_edit.ex
@@ -20,4 +20,9 @@ defmodule Tiktoken.P50KEdit do
   def decode(ids) do
     Tiktoken.Native.p50k_edit_decode(ids)
   end
+
+  @impl Tiktoken.Encoding
+  def count_tokens(text, allowed_special \\ []) do
+    Tiktoken.Native.p50k_edit_count_tokens(text, allowed_special)
+  end
 end

--- a/lib/tiktoken/r50k.ex
+++ b/lib/tiktoken/r50k.ex
@@ -20,4 +20,9 @@ defmodule Tiktoken.R50K do
   def decode(ids) do
     Tiktoken.Native.r50k_decode(ids)
   end
+
+  @impl Tiktoken.Encoding
+  def count_tokens(text, allowed_special \\ []) do
+    Tiktoken.Native.r50k_count_tokens(text, allowed_special)
+  end
 end

--- a/native/tiktoken/src/lib.rs
+++ b/native/tiktoken/src/lib.rs
@@ -57,12 +57,9 @@ fn p50k_decode(ids: Vec<usize>) -> Result<String, String> {
 
 #[rustler::nif]
 fn p50k_count_tokens(text: &str, allowed_special: Vec<&str>) -> Result<usize, String> {
-    let set = HashSet::from_iter(allowed_special.iter().cloned());
-    let bpe = tiktoken_rs::p50k_base_singleton();
-    {
-        let guard = bpe.lock();
-        Ok(guard.encode(text, set).len())
-    }
+    let set: HashSet<&str> = allowed_special.into_iter().collect();
+    let bpe = tiktoken_rs::p50k_base().map_err(|e| e.to_string())?;
+    Ok(bpe.encode(text, set).len())
 }
 
 // p50k edit
@@ -109,12 +106,9 @@ fn p50k_edit_decode(ids: Vec<usize>) -> Result<String, String> {
 
 #[rustler::nif]
 fn p50k_edit_count_tokens(text: &str, allowed_special: Vec<&str>) -> Result<usize, String> {
-    let set = HashSet::from_iter(allowed_special.iter().cloned());
-    let bpe = tiktoken_rs::p50k_edit_singleton();
-    {
-        let guard = bpe.lock();
-        Ok(guard.encode(text, set).len())
-    }
+    let set: HashSet<&str> = allowed_special.into_iter().collect();
+    let bpe = tiktoken_rs::p50k_edit().map_err(|e| e.to_string())?;
+    Ok(bpe.encode(text, set).len())
 }
 
 // r50k
@@ -161,12 +155,9 @@ fn r50k_decode(ids: Vec<usize>) -> Result<String, String> {
 
 #[rustler::nif]
 fn r50k_count_tokens(text: &str, allowed_special: Vec<&str>) -> Result<usize, String> {
-    let set = HashSet::from_iter(allowed_special.iter().cloned());
-    let bpe = tiktoken_rs::r50k_base_singleton();
-    {
-        let guard = bpe.lock();
-        Ok(guard.encode(text, set).len())
-    }
+    let set: HashSet<&str> = allowed_special.into_iter().collect();
+    let bpe = tiktoken_rs::r50k_base().map_err(|e| e.to_string())?;
+    Ok(bpe.encode(text, set).len())
 }
 
 // cl100k
@@ -213,12 +204,9 @@ fn cl100k_decode(ids: Vec<usize>) -> Result<String, String> {
 
 #[rustler::nif]
 fn cl100k_count_tokens(text: &str, allowed_special: Vec<&str>) -> Result<usize, String> {
-    let set = HashSet::from_iter(allowed_special.iter().cloned());
-    let bpe = tiktoken_rs::cl100k_base_singleton();
-    {
-        let guard = bpe.lock();
-        Ok(guard.encode(text, set).len())
-    }
+    let set: HashSet<&str> = allowed_special.into_iter().collect();
+    let bpe = tiktoken_rs::cl100k_base().map_err(|e| e.to_string())?;
+    Ok(bpe.encode(text, set).len())
 }
 
 // o200k
@@ -265,12 +253,9 @@ fn o200k_decode(ids: Vec<usize>) -> Result<String, String> {
 
 #[rustler::nif]
 fn o200k_count_tokens(text: &str, allowed_special: Vec<&str>) -> Result<usize, String> {
-    let set = HashSet::from_iter(allowed_special.iter().cloned());
-    let bpe = tiktoken_rs::o200k_base_singleton();
-    {
-        let guard = bpe.lock();
-        Ok(guard.encode(text, set).len())
-    }
+    let set: HashSet<&str> = allowed_special.into_iter().collect();
+    let bpe = tiktoken_rs::o200k_base().map_err(|e| e.to_string())?;
+    Ok(bpe.encode(text, set).len())
 }
 
 #[rustler::nif]

--- a/native/tiktoken/src/lib.rs
+++ b/native/tiktoken/src/lib.rs
@@ -55,6 +55,16 @@ fn p50k_decode(ids: Vec<usize>) -> Result<String, String> {
     }
 }
 
+#[rustler::nif]
+fn p50k_count_tokens(text: &str, allowed_special: Vec<&str>) -> Result<usize, String> {
+    let set = HashSet::from_iter(allowed_special.iter().cloned());
+    let bpe = tiktoken_rs::p50k_base_singleton();
+    {
+        let guard = bpe.lock();
+        Ok(guard.encode(text, set).len())
+    }
+}
+
 // p50k edit
 
 #[rustler::nif]
@@ -97,6 +107,16 @@ fn p50k_edit_decode(ids: Vec<usize>) -> Result<String, String> {
     }
 }
 
+#[rustler::nif]
+fn p50k_edit_count_tokens(text: &str, allowed_special: Vec<&str>) -> Result<usize, String> {
+    let set = HashSet::from_iter(allowed_special.iter().cloned());
+    let bpe = tiktoken_rs::p50k_edit_singleton();
+    {
+        let guard = bpe.lock();
+        Ok(guard.encode(text, set).len())
+    }
+}
+
 // r50k
 
 #[rustler::nif]
@@ -136,6 +156,16 @@ fn r50k_decode(ids: Vec<usize>) -> Result<String, String> {
             Ok(text) => Ok(text),
             Err(e) => Err(e.to_string()),
         }
+    }
+}
+
+#[rustler::nif]
+fn r50k_count_tokens(text: &str, allowed_special: Vec<&str>) -> Result<usize, String> {
+    let set = HashSet::from_iter(allowed_special.iter().cloned());
+    let bpe = tiktoken_rs::r50k_base_singleton();
+    {
+        let guard = bpe.lock();
+        Ok(guard.encode(text, set).len())
     }
 }
 
@@ -182,8 +212,13 @@ fn cl100k_decode(ids: Vec<usize>) -> Result<String, String> {
 }
 
 #[rustler::nif]
-fn context_size_for_model(model: &str) -> usize {
-    tiktoken_rs::model::get_context_size(model)
+fn cl100k_count_tokens(text: &str, allowed_special: Vec<&str>) -> Result<usize, String> {
+    let set = HashSet::from_iter(allowed_special.iter().cloned());
+    let bpe = tiktoken_rs::cl100k_base_singleton();
+    {
+        let guard = bpe.lock();
+        Ok(guard.encode(text, set).len())
+    }
 }
 
 // o200k
@@ -228,6 +263,21 @@ fn o200k_decode(ids: Vec<usize>) -> Result<String, String> {
     }
 }
 
+#[rustler::nif]
+fn o200k_count_tokens(text: &str, allowed_special: Vec<&str>) -> Result<usize, String> {
+    let set = HashSet::from_iter(allowed_special.iter().cloned());
+    let bpe = tiktoken_rs::o200k_base_singleton();
+    {
+        let guard = bpe.lock();
+        Ok(guard.encode(text, set).len())
+    }
+}
+
+#[rustler::nif]
+fn context_size_for_model(model: &str) -> usize {
+    tiktoken_rs::model::get_context_size(model)
+}
+
 rustler::init!(
     "Elixir.Tiktoken.Native",
     [
@@ -236,22 +286,27 @@ rustler::init!(
         p50k_encode,
         p50k_encode_with_special_tokens,
         p50k_decode,
+        p50k_count_tokens,
         p50k_edit_encode_ordinary,
         p50k_edit_encode,
         p50k_edit_encode_with_special_tokens,
         p50k_edit_decode,
+        p50k_edit_count_tokens,
         r50k_encode_ordinary,
         r50k_encode,
         r50k_encode_with_special_tokens,
         r50k_decode,
+        r50k_count_tokens,
         cl100k_encode_ordinary,
         cl100k_encode,
         cl100k_encode_with_special_tokens,
         cl100k_decode,
+        cl100k_count_tokens,
         o200k_encode_ordinary,
         o200k_encode,
         o200k_encode_with_special_tokens,
         o200k_decode,
+        o200k_count_tokens,
         context_size_for_model
     ]
 );

--- a/test/tiktoken_test.exs
+++ b/test/tiktoken_test.exs
@@ -136,6 +136,39 @@ defmodule TiktokenTest do
     end
   end
 
+  describe "count_tokens/2" do
+    test "with supported model" do
+      text = "Tell me more about Elixir!"
+      assert {:ok, count} = Tiktoken.count_tokens("gpt-3.5-turbo", text)
+      assert count > 0
+      assert count == length(elem(Tiktoken.encode("gpt-3.5-turbo", text), 1))
+    end
+
+    test "with unsupported model" do
+      assert {:error, {:unsupported_model, "gpt2"}} =
+               Tiktoken.count_tokens("gpt2", "Hello")
+    end
+
+    test "with special tokens" do
+      text = "Tell me more about Elixir!"
+      special_tokens = ["<|endoftext|>"]
+      assert {:ok, count} = Tiktoken.count_tokens("gpt-3.5-turbo", text, special_tokens)
+      assert count > 0
+      assert count == length(elem(Tiktoken.encode("gpt-3.5-turbo", text, special_tokens), 1))
+    end
+
+    test "with different models" do
+      text = "Tell me more about Elixir!"
+      models = ["gpt-3.5-turbo", "text-davinci-003", "text-davinci-edit-001"]
+
+      Enum.each(models, fn model ->
+        assert {:ok, count} = Tiktoken.count_tokens(model, text)
+        assert count > 0
+        assert count == length(elem(Tiktoken.encode(model, text), 1))
+      end)
+    end
+  end
+
   describe "context_size_for_model/1" do
     test "get proper context size for model" do
       @known_models


### PR DESCRIPTION
Hi,  
Thanks for publishing this library, it's been very useful!

I need to count tokens for large inputs with high concurrency. Initially, I used encode |> Enum.count, but as concurrency increased, I started noticing slowdowns due to the mutex lock in encode. There's also a small amount of overhead from copying the full list of tokens into Elixir just to count them—due to marshalling and memory allocation.

To address this, I added a `count_tokens` function to each tokenizer. It bypasses the mutex (at the cost of slightly higher memory usage) and skips allocation of the full token list [in elixir], leading to significantly better performance in concurrent scenarios.

Here's a benchmark comparing `encode |> count` with the new `count_tokens` function:

```elixir
text = String.duplicate("Hello, world!", 100_000)
Benchee.run(
  %{
    "encode |> count" => fn ->
        Tiktoken.O200K.encode(text) |> elem(1) |> Enum.count()
    end,
    "count_tokens" => fn -> 
      Tiktoken.O200K.count_tokens(text)
    end
  },
  time: 5,
  memory_time: 2,
  parallel: 10
)
```

Output:

```
Name                      ips        average  deviation         median         99th %
count_tokens             2.90         0.34 s    ±22.24%         0.33 s         0.66 s
encode |> count          0.56         1.77 s    ±16.36%         1.78 s         3.06 s

Comparison: 
count_tokens             2.90
encode |> count          0.56 - 5.15x slower +1.43 s

Memory usage statistics:

Name               Memory usage
count_tokens            0.50 KB
encode |> count         1.49 KB - 2.98x memory usage +0.99 KB
```

Happy to tweak the implementation if needed.