### PR TITLE
Update GH action and Rustler versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,9 @@ jobs:
           - { target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04 , use-cross: true }
           - { target: aarch64-unknown-linux-gnu   , os: ubuntu-20.04 , use-cross: true }
           - { target: aarch64-unknown-linux-musl  , os: ubuntu-20.04 , use-cross: true }
-          - { target: aarch64-apple-darwin        , os: macos-12      }
+          - { target: aarch64-apple-darwin        , os: macos-15      }
           - { target: riscv64gc-unknown-linux-gnu , os: ubuntu-20.04 , use-cross: true }
-          - { target: x86_64-apple-darwin         , os: macos-12      }
+          - { target: x86_64-apple-darwin         , os: macos-15      }
           - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04  }
           - { target: x86_64-unknown-linux-musl   , os: ubuntu-20.04 , use-cross: true }
           - { target: x86_64-pc-windows-gnu       , os: windows-2019  }
@@ -45,7 +45,7 @@ jobs:
 
     - name: Build the project
       id: build-crate
-      uses: philss/rustler-precompiled-action@v1.0.1
+      uses: philss/rustler-precompiled-action@v1.1.4
       with:
         project-name: tiktoken
         project-version: ${{ env.PROJECT_VERSION }}
@@ -55,7 +55,7 @@ jobs:
         project-dir: "native/tiktoken"
 
     - name: Artifact upload
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ steps.build-crate.outputs.file-name }}
         path: ${{ steps.build-crate.outputs.file-path }}

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule Tiktoken.MixProject do
     [
       {:ex_doc, "~> 0.27", only: :dev, runtime: false},
       {:rustler, "~> 0.30.0"},
-      {:rustler_precompiled, "~> 0.7"}
+      {:rustler_precompiled, "~> 0.8"}
     ]
   end
 


### PR DESCRIPTION
The repository fails to build due to:
- `actions/upload-artifact@v3` being deprecated
- `macos-12` runners being deprecated

This PR bumps those versions alongside the `rustler` compile ones.

Once this is merged, it would be great if a new release of the library is done, thank you!