### PR TITLE
Optimization for concurrent environments

### DIFF
--- a/native/tiktoken/src/lib.rs
+++ b/native/tiktoken/src/lib.rs
@@ -1,5 +1,8 @@
+mod thread_local;
+
 use std::collections::HashSet;
 use std::vec::Vec;
+use thread_local::*;
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn encoding_for_model(model: &str) -> Option<&str> {
@@ -17,48 +20,33 @@ fn encoding_for_model(model: &str) -> Option<&str> {
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn p50k_encode_ordinary(text: &str) -> Result<Vec<usize>, String> {
-    let bpe = tiktoken_rs::p50k_base_singleton();
-    {
-        let guard = bpe.lock();
-        Ok(guard.encode_ordinary(text))
-    }
+    let bpe = crate::p50k_base_thread_local();
+    Ok(bpe.encode_ordinary(text))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn p50k_encode(text: &str, allowed_special: Vec<&str>) -> Result<Vec<usize>, String> {
     let set = HashSet::from_iter(allowed_special.iter().cloned());
-    let bpe = tiktoken_rs::p50k_base_singleton();
-    {
-        let guard = bpe.lock();
-        Ok(guard.encode(text, set))
-    }
+    let bpe = crate::p50k_base_thread_local();
+    Ok(bpe.encode(text, set))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn p50k_encode_with_special_tokens(text: &str) -> Result<Vec<usize>, String> {
-    let bpe = tiktoken_rs::p50k_base_singleton();
-    {
-        let guard = bpe.lock();
-        Ok(guard.encode_with_special_tokens(text))
-    }
+    let bpe = crate::p50k_base_thread_local();
+    Ok(bpe.encode_with_special_tokens(text))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn p50k_decode(ids: Vec<usize>) -> Result<String, String> {
-    let bpe = tiktoken_rs::p50k_base_singleton();
-    {
-        let guard = bpe.lock();
-        match guard.decode(ids) {
-            Ok(text) => Ok(text),
-            Err(e) => Err(e.to_string()),
-        }
-    }
+    let bpe = crate::p50k_base_thread_local();
+    bpe.decode(ids).map_err(|e| e.to_string())
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn p50k_count_tokens(text: &str, allowed_special: Vec<&str>) -> Result<usize, String> {
     let set: HashSet<&str> = allowed_special.into_iter().collect();
-    let bpe = tiktoken_rs::p50k_base().map_err(|e| e.to_string())?;
+    let bpe = crate::p50k_base_thread_local();
     Ok(bpe.encode(text, set).len())
 }
 
@@ -66,48 +54,33 @@ fn p50k_count_tokens(text: &str, allowed_special: Vec<&str>) -> Result<usize, St
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn p50k_edit_encode_ordinary(text: &str) -> Result<Vec<usize>, String> {
-    let bpe = tiktoken_rs::p50k_edit_singleton();
-    {
-        let guard = bpe.lock();
-        Ok(guard.encode_ordinary(text))
-    }
+    let bpe = crate::p50k_edit_thread_local();
+    Ok(bpe.encode_ordinary(text))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn p50k_edit_encode(text: &str, allowed_special: Vec<&str>) -> Result<Vec<usize>, String> {
     let set = HashSet::from_iter(allowed_special.iter().cloned());
-    let bpe = tiktoken_rs::p50k_edit_singleton();
-    {
-        let guard = bpe.lock();
-        Ok(guard.encode(text, set))
-    }
+    let bpe = crate::p50k_edit_thread_local();
+    Ok(bpe.encode(text, set))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn p50k_edit_encode_with_special_tokens(text: &str) -> Result<Vec<usize>, String> {
-    let bpe = tiktoken_rs::p50k_edit_singleton();
-    {
-        let guard = bpe.lock();
-        Ok(guard.encode_with_special_tokens(text))
-    }
+    let bpe = crate::p50k_edit_thread_local();
+    Ok(bpe.encode_with_special_tokens(text))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn p50k_edit_decode(ids: Vec<usize>) -> Result<String, String> {
-    let bpe = tiktoken_rs::p50k_edit_singleton();
-    {
-        let guard = bpe.lock();
-        match guard.decode(ids) {
-            Ok(text) => Ok(text),
-            Err(e) => Err(e.to_string()),
-        }
-    }
+    let bpe = crate::p50k_edit_thread_local();
+    bpe.decode(ids).map_err(|e| e.to_string())
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn p50k_edit_count_tokens(text: &str, allowed_special: Vec<&str>) -> Result<usize, String> {
     let set: HashSet<&str> = allowed_special.into_iter().collect();
-    let bpe = tiktoken_rs::p50k_edit().map_err(|e| e.to_string())?;
+    let bpe = crate::p50k_edit_thread_local();
     Ok(bpe.encode(text, set).len())
 }
 
@@ -115,48 +88,33 @@ fn p50k_edit_count_tokens(text: &str, allowed_special: Vec<&str>) -> Result<usiz
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn r50k_encode_ordinary(text: &str) -> Result<Vec<usize>, String> {
-    let bpe = tiktoken_rs::r50k_base_singleton();
-    {
-        let guard = bpe.lock();
-        Ok(guard.encode_ordinary(text))
-    }
+    let bpe = crate::r50k_base_thread_local();
+    Ok(bpe.encode_ordinary(text))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn r50k_encode(text: &str, allowed_special: Vec<&str>) -> Result<Vec<usize>, String> {
     let set = HashSet::from_iter(allowed_special.iter().cloned());
-    let bpe = tiktoken_rs::r50k_base_singleton();
-    {
-        let guard = bpe.lock();
-        Ok(guard.encode(text, set))
-    }
+    let bpe = crate::r50k_base_thread_local();
+    Ok(bpe.encode(text, set))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn r50k_encode_with_special_tokens(text: &str) -> Result<Vec<usize>, String> {
-    let bpe = tiktoken_rs::r50k_base_singleton();
-    {
-        let guard = bpe.lock();
-        Ok(guard.encode_with_special_tokens(text))
-    }
+    let bpe = crate::r50k_base_thread_local();
+    Ok(bpe.encode_with_special_tokens(text))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn r50k_decode(ids: Vec<usize>) -> Result<String, String> {
-    let bpe = tiktoken_rs::r50k_base_singleton();
-    {
-        let guard = bpe.lock();
-        match guard.decode(ids) {
-            Ok(text) => Ok(text),
-            Err(e) => Err(e.to_string()),
-        }
-    }
+    let bpe = crate::r50k_base_thread_local();
+    bpe.decode(ids).map_err(|e| e.to_string())
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn r50k_count_tokens(text: &str, allowed_special: Vec<&str>) -> Result<usize, String> {
     let set: HashSet<&str> = allowed_special.into_iter().collect();
-    let bpe = tiktoken_rs::r50k_base().map_err(|e| e.to_string())?;
+    let bpe = crate::r50k_base_thread_local();
     Ok(bpe.encode(text, set).len())
 }
 
@@ -164,48 +122,33 @@ fn r50k_count_tokens(text: &str, allowed_special: Vec<&str>) -> Result<usize, St
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn cl100k_encode_ordinary(text: &str) -> Result<Vec<usize>, String> {
-    let bpe = tiktoken_rs::cl100k_base_singleton();
-    {
-        let guard = bpe.lock();
-        Ok(guard.encode_ordinary(text))
-    }
+    let bpe = crate::cl100k_base_thread_local();
+    Ok(bpe.encode_ordinary(text))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn cl100k_encode(text: &str, allowed_special: Vec<&str>) -> Result<Vec<usize>, String> {
     let set = HashSet::from_iter(allowed_special.iter().cloned());
-    let bpe = tiktoken_rs::cl100k_base_singleton();
-    {
-        let guard = bpe.lock();
-        Ok(guard.encode(text, set))
-    }
+    let bpe = crate::cl100k_base_thread_local();
+    Ok(bpe.encode(text, set))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn cl100k_encode_with_special_tokens(text: &str) -> Result<Vec<usize>, String> {
-    let bpe = tiktoken_rs::cl100k_base_singleton();
-    {
-        let guard = bpe.lock();
-        Ok(guard.encode_with_special_tokens(text))
-    }
+    let bpe = crate::cl100k_base_thread_local();
+    Ok(bpe.encode_with_special_tokens(text))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn cl100k_decode(ids: Vec<usize>) -> Result<String, String> {
-    let bpe = tiktoken_rs::cl100k_base_singleton();
-    {
-        let guard = bpe.lock();
-        match guard.decode(ids) {
-            Ok(text) => Ok(text),
-            Err(e) => Err(e.to_string()),
-        }
-    }
+    let bpe = crate::cl100k_base_thread_local();
+    bpe.decode(ids).map_err(|e| e.to_string())
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn cl100k_count_tokens(text: &str, allowed_special: Vec<&str>) -> Result<usize, String> {
     let set: HashSet<&str> = allowed_special.into_iter().collect();
-    let bpe = tiktoken_rs::cl100k_base().map_err(|e| e.to_string())?;
+    let bpe = crate::cl100k_base_thread_local();
     Ok(bpe.encode(text, set).len())
 }
 
@@ -213,48 +156,33 @@ fn cl100k_count_tokens(text: &str, allowed_special: Vec<&str>) -> Result<usize, 
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn o200k_encode_ordinary(text: &str) -> Result<Vec<usize>, String> {
-    let bpe = tiktoken_rs::o200k_base_singleton();
-    {
-        let guard = bpe.lock();
-        Ok(guard.encode_ordinary(text))
-    }
+    let bpe = crate::o200k_base_thread_local();
+    Ok(bpe.encode_ordinary(text))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn o200k_encode(text: &str, allowed_special: Vec<&str>) -> Result<Vec<usize>, String> {
     let set = HashSet::from_iter(allowed_special.iter().cloned());
-    let bpe = tiktoken_rs::o200k_base_singleton();
-    {
-        let guard = bpe.lock();
-        Ok(guard.encode(text, set))
-    }
+    let bpe = crate::o200k_base_thread_local();
+    Ok(bpe.encode(text, set))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn o200k_encode_with_special_tokens(text: &str) -> Result<Vec<usize>, String> {
-    let bpe = tiktoken_rs::o200k_base_singleton();
-    {
-        let guard = bpe.lock();
-        Ok(guard.encode_with_special_tokens(text))
-    }
+    let bpe = crate::o200k_base_thread_local();
+    Ok(bpe.encode_with_special_tokens(text))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn o200k_decode(ids: Vec<usize>) -> Result<String, String> {
-    let bpe = tiktoken_rs::o200k_base_singleton();
-    {
-        let guard = bpe.lock();
-        match guard.decode(ids) {
-            Ok(text) => Ok(text),
-            Err(e) => Err(e.to_string()),
-        }
-    }
+    let bpe = crate::o200k_base_thread_local();
+    bpe.decode(ids).map_err(|e| e.to_string())
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 fn o200k_count_tokens(text: &str, allowed_special: Vec<&str>) -> Result<usize, String> {
     let set: HashSet<&str> = allowed_special.into_iter().collect();
-    let bpe = tiktoken_rs::o200k_base().map_err(|e| e.to_string())?;
+    let bpe = crate::o200k_base_thread_local();
     Ok(bpe.encode(text, set).len())
 }
 

--- a/native/tiktoken/src/lib.rs
+++ b/native/tiktoken/src/lib.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::vec::Vec;
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn encoding_for_model(model: &str) -> Option<&str> {
     match tiktoken_rs::tokenizer::get_tokenizer(model) {
         Some(tiktoken_rs::tokenizer::Tokenizer::O200kBase) => Some("o200k_base"),
@@ -15,7 +15,7 @@ fn encoding_for_model(model: &str) -> Option<&str> {
 
 // p50k
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn p50k_encode_ordinary(text: &str) -> Result<Vec<usize>, String> {
     let bpe = tiktoken_rs::p50k_base_singleton();
     {
@@ -24,7 +24,7 @@ fn p50k_encode_ordinary(text: &str) -> Result<Vec<usize>, String> {
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn p50k_encode(text: &str, allowed_special: Vec<&str>) -> Result<Vec<usize>, String> {
     let set = HashSet::from_iter(allowed_special.iter().cloned());
     let bpe = tiktoken_rs::p50k_base_singleton();
@@ -34,7 +34,7 @@ fn p50k_encode(text: &str, allowed_special: Vec<&str>) -> Result<Vec<usize>, Str
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn p50k_encode_with_special_tokens(text: &str) -> Result<Vec<usize>, String> {
     let bpe = tiktoken_rs::p50k_base_singleton();
     {
@@ -43,7 +43,7 @@ fn p50k_encode_with_special_tokens(text: &str) -> Result<Vec<usize>, String> {
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn p50k_decode(ids: Vec<usize>) -> Result<String, String> {
     let bpe = tiktoken_rs::p50k_base_singleton();
     {
@@ -55,7 +55,7 @@ fn p50k_decode(ids: Vec<usize>) -> Result<String, String> {
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn p50k_count_tokens(text: &str, allowed_special: Vec<&str>) -> Result<usize, String> {
     let set: HashSet<&str> = allowed_special.into_iter().collect();
     let bpe = tiktoken_rs::p50k_base().map_err(|e| e.to_string())?;
@@ -64,7 +64,7 @@ fn p50k_count_tokens(text: &str, allowed_special: Vec<&str>) -> Result<usize, St
 
 // p50k edit
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn p50k_edit_encode_ordinary(text: &str) -> Result<Vec<usize>, String> {
     let bpe = tiktoken_rs::p50k_edit_singleton();
     {
@@ -73,7 +73,7 @@ fn p50k_edit_encode_ordinary(text: &str) -> Result<Vec<usize>, String> {
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn p50k_edit_encode(text: &str, allowed_special: Vec<&str>) -> Result<Vec<usize>, String> {
     let set = HashSet::from_iter(allowed_special.iter().cloned());
     let bpe = tiktoken_rs::p50k_edit_singleton();
@@ -83,7 +83,7 @@ fn p50k_edit_encode(text: &str, allowed_special: Vec<&str>) -> Result<Vec<usize>
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn p50k_edit_encode_with_special_tokens(text: &str) -> Result<Vec<usize>, String> {
     let bpe = tiktoken_rs::p50k_edit_singleton();
     {
@@ -92,7 +92,7 @@ fn p50k_edit_encode_with_special_tokens(text: &str) -> Result<Vec<usize>, String
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn p50k_edit_decode(ids: Vec<usize>) -> Result<String, String> {
     let bpe = tiktoken_rs::p50k_edit_singleton();
     {
@@ -104,7 +104,7 @@ fn p50k_edit_decode(ids: Vec<usize>) -> Result<String, String> {
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn p50k_edit_count_tokens(text: &str, allowed_special: Vec<&str>) -> Result<usize, String> {
     let set: HashSet<&str> = allowed_special.into_iter().collect();
     let bpe = tiktoken_rs::p50k_edit().map_err(|e| e.to_string())?;
@@ -113,7 +113,7 @@ fn p50k_edit_count_tokens(text: &str, allowed_special: Vec<&str>) -> Result<usiz
 
 // r50k
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn r50k_encode_ordinary(text: &str) -> Result<Vec<usize>, String> {
     let bpe = tiktoken_rs::r50k_base_singleton();
     {
@@ -122,7 +122,7 @@ fn r50k_encode_ordinary(text: &str) -> Result<Vec<usize>, String> {
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn r50k_encode(text: &str, allowed_special: Vec<&str>) -> Result<Vec<usize>, String> {
     let set = HashSet::from_iter(allowed_special.iter().cloned());
     let bpe = tiktoken_rs::r50k_base_singleton();
@@ -132,7 +132,7 @@ fn r50k_encode(text: &str, allowed_special: Vec<&str>) -> Result<Vec<usize>, Str
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn r50k_encode_with_special_tokens(text: &str) -> Result<Vec<usize>, String> {
     let bpe = tiktoken_rs::r50k_base_singleton();
     {
@@ -141,7 +141,7 @@ fn r50k_encode_with_special_tokens(text: &str) -> Result<Vec<usize>, String> {
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn r50k_decode(ids: Vec<usize>) -> Result<String, String> {
     let bpe = tiktoken_rs::r50k_base_singleton();
     {
@@ -153,7 +153,7 @@ fn r50k_decode(ids: Vec<usize>) -> Result<String, String> {
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn r50k_count_tokens(text: &str, allowed_special: Vec<&str>) -> Result<usize, String> {
     let set: HashSet<&str> = allowed_special.into_iter().collect();
     let bpe = tiktoken_rs::r50k_base().map_err(|e| e.to_string())?;
@@ -162,7 +162,7 @@ fn r50k_count_tokens(text: &str, allowed_special: Vec<&str>) -> Result<usize, St
 
 // cl100k
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn cl100k_encode_ordinary(text: &str) -> Result<Vec<usize>, String> {
     let bpe = tiktoken_rs::cl100k_base_singleton();
     {
@@ -171,7 +171,7 @@ fn cl100k_encode_ordinary(text: &str) -> Result<Vec<usize>, String> {
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn cl100k_encode(text: &str, allowed_special: Vec<&str>) -> Result<Vec<usize>, String> {
     let set = HashSet::from_iter(allowed_special.iter().cloned());
     let bpe = tiktoken_rs::cl100k_base_singleton();
@@ -181,7 +181,7 @@ fn cl100k_encode(text: &str, allowed_special: Vec<&str>) -> Result<Vec<usize>, S
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn cl100k_encode_with_special_tokens(text: &str) -> Result<Vec<usize>, String> {
     let bpe = tiktoken_rs::cl100k_base_singleton();
     {
@@ -190,7 +190,7 @@ fn cl100k_encode_with_special_tokens(text: &str) -> Result<Vec<usize>, String> {
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn cl100k_decode(ids: Vec<usize>) -> Result<String, String> {
     let bpe = tiktoken_rs::cl100k_base_singleton();
     {
@@ -202,7 +202,7 @@ fn cl100k_decode(ids: Vec<usize>) -> Result<String, String> {
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn cl100k_count_tokens(text: &str, allowed_special: Vec<&str>) -> Result<usize, String> {
     let set: HashSet<&str> = allowed_special.into_iter().collect();
     let bpe = tiktoken_rs::cl100k_base().map_err(|e| e.to_string())?;
@@ -211,7 +211,7 @@ fn cl100k_count_tokens(text: &str, allowed_special: Vec<&str>) -> Result<usize, 
 
 // o200k
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn o200k_encode_ordinary(text: &str) -> Result<Vec<usize>, String> {
     let bpe = tiktoken_rs::o200k_base_singleton();
     {
@@ -220,7 +220,7 @@ fn o200k_encode_ordinary(text: &str) -> Result<Vec<usize>, String> {
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn o200k_encode(text: &str, allowed_special: Vec<&str>) -> Result<Vec<usize>, String> {
     let set = HashSet::from_iter(allowed_special.iter().cloned());
     let bpe = tiktoken_rs::o200k_base_singleton();
@@ -230,7 +230,7 @@ fn o200k_encode(text: &str, allowed_special: Vec<&str>) -> Result<Vec<usize>, St
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn o200k_encode_with_special_tokens(text: &str) -> Result<Vec<usize>, String> {
     let bpe = tiktoken_rs::o200k_base_singleton();
     {
@@ -239,7 +239,7 @@ fn o200k_encode_with_special_tokens(text: &str) -> Result<Vec<usize>, String> {
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn o200k_decode(ids: Vec<usize>) -> Result<String, String> {
     let bpe = tiktoken_rs::o200k_base_singleton();
     {
@@ -251,14 +251,14 @@ fn o200k_decode(ids: Vec<usize>) -> Result<String, String> {
     }
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn o200k_count_tokens(text: &str, allowed_special: Vec<&str>) -> Result<usize, String> {
     let set: HashSet<&str> = allowed_special.into_iter().collect();
     let bpe = tiktoken_rs::o200k_base().map_err(|e| e.to_string())?;
     Ok(bpe.encode(text, set).len())
 }
 
-#[rustler::nif]
+#[rustler::nif(schedule = "DirtyCpu")]
 fn context_size_for_model(model: &str) -> usize {
     tiktoken_rs::model::get_context_size(model)
 }

--- a/native/tiktoken/src/thread_local.rs
+++ b/native/tiktoken/src/thread_local.rs
@@ -1,0 +1,57 @@
+use tiktoken_rs::CoreBPE;
+use tiktoken_rs::{cl100k_base, o200k_base, p50k_base, p50k_edit, r50k_base};
+
+/// Returns a thread local instance of the r50k_base tokenizer. (also known as `gpt2`)
+/// Use for GPT-3 models like `davinci`
+///
+/// This function will only initialize the tokenizer once per thread, and then return a reference the tokenizer
+pub fn r50k_base_thread_local() -> CoreBPE {
+    thread_local! {
+        static R50K_BASE: CoreBPE = r50k_base().unwrap();
+    }
+    R50K_BASE.with(|bpe| bpe.clone())
+}
+
+/// Returns a thread local instance of the p50k_base tokenizer.
+/// Use for Code models, `text-davinci-002`, `text-davinci-003`
+///
+/// This function will only initialize the tokenizer once per thread, and then return a reference the tokenizer.
+pub fn p50k_base_thread_local() -> CoreBPE {
+    thread_local! {
+        static P50K_BASE: CoreBPE = p50k_base().unwrap();
+    }
+    P50K_BASE.with(|bpe| bpe.clone())
+}
+
+/// Returns a thread local instance of the p50k_edit tokenizer.
+/// Use for edit models like `text-davinci-edit-001`, `code-davinci-edit-001`
+///
+/// This function will only initialize the tokenizer once per thread, and then return a reference the tokenizer.
+pub fn p50k_edit_thread_local() -> CoreBPE {
+    thread_local! {
+        static P50K_EDIT: CoreBPE = p50k_edit().unwrap();
+    }
+    P50K_EDIT.with(|bpe| bpe.clone())
+}
+
+/// Returns a thread local instance of the cl100k_base tokenizer.
+/// Use for ChatGPT models, `text-embedding-ada-002`
+///
+/// This function will only initialize the tokenizer once per thread, and then return a reference the tokenizer
+pub fn cl100k_base_thread_local() -> CoreBPE {
+    thread_local! {
+        static CL100K_BASE: CoreBPE = cl100k_base().unwrap();
+    }
+    CL100K_BASE.with(|bpe| bpe.clone())
+}
+
+/// Returns a thread local instance of the o200k_base tokenizer.
+/// Use for GPT-4o models.
+///
+/// This function will only initialize the tokenizer once per thread, and then return a reference the tokenizer
+pub fn o200k_base_thread_local() -> CoreBPE {
+    thread_local! {
+        static O200K_BASE: CoreBPE = o200k_base().unwrap();
+    }
+    O200K_BASE.with(|bpe| bpe.clone())
+}


### PR DESCRIPTION
This PR optimizes the library for better use in concurrent environments;
1. Mark all functions with `schedule = "DirtyCpu")` to ensure the main Beam scheduler does not wait on rather slow tiktoken functions. NIFs should generally execute in under 1 ms for the scheduler work as intended. This can lead to scheduler collapse (more on [that here](https://gist.github.com/chewbranca/07d9a6eed3da7b490b47)). Marking the functions as "DirtyCpu" elevates this a bit as a separate scheduler will be used. 
2. Instead of using a singleton tokenizer, create one per thread using thread locals. This performs marginally better than creating a new tokenizer on demand and much better than a singleton.


Benchee results for 16 parallel execution on 8 cores to tokenize 1 million words:
```
Name                          ips        average  deviation         median         99th %
count thread local           1.33      752.04 ms    ±12.26%      735.96 ms     1049.66 ms
encode thread local          1.30      771.91 ms     ±6.77%      769.04 ms      885.09 ms
encode no cache              1.17      853.15 ms     ±6.05%      851.28 ms      972.03 ms
encode singleton             0.22     4452.14 ms    ±33.68%     5314.44 ms     5374.20 ms

Comparison: 
count thread local           1.33
encode thread local          1.30 - 1.03x slower +19.88 ms
encode no cache              1.17 - 1.13x slower +101.11 ms
encode singleton             0.22 - 5.92x slower +3700.11 ms
```